### PR TITLE
In LHO: add arg, fix some lock-up bugs, change some channel types

### DIFF
--- a/LHO-Server.py
+++ b/LHO-Server.py
@@ -15,9 +15,9 @@ def func(n):  ## creates all our EPIC variables
         starter = f"STATION_0{i}_" if i < 10 else f"STATION_{i}_"
         dic[starter + "LON"] = {'prec' : 3}  ## longitude
         dic[starter + "LAT"] = {'prec' : 3}  ## latitude
-        dic[starter + "MIN"] = {'type' : 'int'}  ## min value of station
-        dic[starter + "MAX"] = {'type' : 'int'}  ## max value of station
-        dic[starter + "MEAN"] = {'type' : 'int'}  ## mean value of station
+        dic[starter + "MIN"] = {'prec' : 3}  ## min value of station
+        dic[starter + "MAX"] = {'prec' : 3}  ## max value of station
+        dic[starter + "MEAN"] = {'prec' : 3}  ## mean value of station
         dic[starter + "ID"] = {'type' : 'int'}  ## hex value of string
         dic[starter + "NAME"] = {'type' : 'str'}  ## string version of ID
         dicts.append(dic)

--- a/LHO_picket_fence.py
+++ b/LHO_picket_fence.py
@@ -325,7 +325,7 @@ class SeedlinkPlotter(tkinter.Tk):
             if self.send_epics:
                 caput("H1:SEI-USGS_NETWORK_AUX1", -1)
         # Change equal_scale to False if auto-scaling should be turned off
-        stream.plot(fig=fig, method="fast", draw=False, equal_scale=True,
+        stream.plot(fig=fig, method="fast", draw=False, equal_scale=False,
                     size=(self.args.x_size, self.args.y_size), title="",
                     color='Blue', tick_format=self.args.tick_format,
                     number_of_ticks=self.args.time_tick_nb, min_bound=self.threshold)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ ___________
 
 RUNNING THE PROGRAM:
 
-To run, just open a terminal, go to the directory where you stored the file, and enter the command `python3 LLO_picket_fence.py` or `python3 LHO-picket-fence.py` depending on the file you downloaded. It is recommended to run `python3 LLO-Server.py` before running the LLO/LHO Picket Fence due to the addition of EPICs variables to the code. This will simply initialize the EPICs variables with the desired starting values (such as -1). 
+To run, just open a terminal, go to the directory where you stored the file, and enter the command `python3 LLO_picket_fence.py` or `python3 LHO-picket-fence.py --epics` depending on the file you downloaded. It is recommended to run `python3 LLO-Server.py` before running the LLO/LHO Picket Fence due to the addition of EPICs variables to the code. This will simply initialize the EPICs variables with the desired starting values (such as -1). 
 
 You may run the Picket Fence with the default parameters already chosen by me (the optional parameters I have set are good fits). When an earthquake crosses our preset threshold, the background for the plot of the station measuring the earthquake will turn a certain color. If the background is gray, then the seismic activity from the picket station is deemed to be normal. If the background is yellow, the seismic activity from the picket station is deemed to be slightly abnormal. If the background is orange, the seismic activity from the picket station is deemed to be fairly abnormal. If the background is red, the seismic activity from the picket station is deemed to be extremely abnormal and is most likely a large earthquake. If the background is teal, then that picket station is suspected of being glitched and its data should be taken with a grain of salt until the picket station is no longer teal (it will not affect NETWORK EPICs variables). Channel AUX1 of the EPICs variables channels is being used to record the picket number which is glitching. Default value is -1. If a station is not being plotted, this is because it is currently down/not feeding us data.
 
@@ -25,6 +25,8 @@ ___________
 OPTIONAL PARAMETERS (optional reading):
 
 This program has many optional parameters and flags that can be changed:
+
+At LHO, the --epics flag must be included for Picket Fence to set EPICS channels.  Only one instance of Picket Fence should be run with the --epics flag.
 
 Stations can be changed by -s or --seedlink_streams \[SEEDLINK_STREAMS\]
 


### PR DESCRIPTION
MIN-MAX-MEAN EPICS channel types are changed to floating point

epics arg now really needed for all epics "caput"

"caput" changed from subprocess.popen to pyepics.caput function calls

two bugs that were causing lock ups were fixed:
Time array input into lsim sometimes would have a different size than the input array. These are now forced to be the same size.

min() call that limited lookback to 15 minutes could return a floating point, but this value needs to be an integer so it can be used as a l ist index.