### PR TITLE
Fix to work at LHO

### DIFF
--- a/LHO-Server.py
+++ b/LHO-Server.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 from pcaspy import Driver, SimpleServer
-from gwpy.time import tconvert
 
 class myDriver(Driver):
     def  __init__(self):
@@ -82,8 +81,8 @@ def main():
     driver.setParam("NETWORK_AUX2", -1)
     driver.setParam("NETWORK_AUX3", -1)
     driver.setParam("NETWORK_STATION_NAME", "")
-    driver.setParam("SERVER_START_GPS", tconvert("now").seconds)
-    driver.setParam("SERVER_GPS", tconvert("now").seconds)
+    driver.setParam("SERVER_START_GPS", 0)
+    driver.setParam("SERVER_GPS", 0)
     
     # process CA transactions
     while True:

--- a/Picket_fence_code_v2.py
+++ b/Picket_fence_code_v2.py
@@ -646,7 +646,8 @@ class SeedlinkPlotter(tkinter.Tk):
             subprocess.Popen(["caput", prefix + "NETWORK_PEAK", f"{max_val}"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
             subprocess.Popen(["caput", prefix + "NETWORK_STATION_NUM", f"{self.pickets[stream[idx].stats.station]['index']}"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
             subprocess.Popen(["caput", prefix + "NETWORK_STATION_NAME", f"{stream[idx].stats.station}"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-            subprocess.Popen(["caput", prefix + "SERVER_GPS", f"{tconvert('now').seconds}"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            subprocess.Popen(["caput", prefix + "SERVER_GPS", f"{tconvert('now').gpsSeconds}"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            subprocess.Popen(["caput", prefix + "SERVER_START_GPS", start_time], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
         fig.canvas.draw()
 			                
@@ -692,8 +693,8 @@ def initEpics(picket_dict, prefix): #TODO: Migrate this function to the EPICS se
                 subprocess.Popen(["caput", prefix + starter + "MEAN", "-1"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
                 subprocess.Popen(["caput", prefix + starter + "ID", f"{ID_Creator(statName)}"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
                 subprocess.Popen(["caput", prefix + starter + "NAME", f"{statName}"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)           
-    subprocess.Popen(["caput", prefix + "SERVER_GPS", f"{tconvert('now').seconds}"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-    subprocess.Popen(["caput", prefix + "SERVER_START_GPS", start_time, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    subprocess.Popen(["caput", prefix + "SERVER_GPS", f"{tconvert('now').gpsSeconds}"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    subprocess.Popen(["caput", prefix + "SERVER_START_GPS", start_time], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
     
 
 #def updateEpics(picket_dict, prefix, updateMetadata):
@@ -711,7 +712,8 @@ class PicketFence():
         self.args.epics_prefix=epics_prefix
 
     def run(self):
-        start_time = f"{tconvert('now').seconds}"
+        global start_time
+        start_time = f"{tconvert('now').gpsSeconds}"
         while self.leave[0]==False:
             self.startnow = UTCDateTime()
             self.stream = Stream()

--- a/Picket_fence_code_v2.py
+++ b/Picket_fence_code_v2.py
@@ -672,6 +672,8 @@ def Reverse_ID(n):
         result += chr(int(s[i:i+2], 16))
     return result
 
+start_time = "not started"
+
 def initEpics(picket_dict, prefix): #TODO: Migrate this function to the EPICS server code
 
     subprocess.Popen(["caput", prefix + "NETWORK_PEAK", "-1"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
@@ -691,6 +693,7 @@ def initEpics(picket_dict, prefix): #TODO: Migrate this function to the EPICS se
                 subprocess.Popen(["caput", prefix + starter + "ID", f"{ID_Creator(statName)}"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
                 subprocess.Popen(["caput", prefix + starter + "NAME", f"{statName}"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)           
     subprocess.Popen(["caput", prefix + "SERVER_GPS", f"{tconvert('now').seconds}"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    subprocess.Popen(["caput", prefix + "SERVER_START_GPS", start_time, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
     
 
 #def updateEpics(picket_dict, prefix, updateMetadata):
@@ -708,6 +711,7 @@ class PicketFence():
         self.args.epics_prefix=epics_prefix
 
     def run(self):
+        start_time = f"{tconvert('now').seconds}"
         while self.leave[0]==False:
             self.startnow = UTCDateTime()
             self.stream = Stream()


### PR DESCRIPTION
Some fixes needed to work at LHO.

Also, change start time to report start of Picket Fence client rather than start of EPICS server.  This change also eliminates a dependency on gwpy in the EPICS server.