### PR TITLE
Patches to try to keep PicketFence from restarting at LHO

### DIFF
--- a/Picket_fence_code_v2.py
+++ b/Picket_fence_code_v2.py
@@ -370,22 +370,21 @@ class filteredStream(Stream):
                     dt = trace.stats.delta
                     newTrace=trace.slice(starttime=oldEndtime+dt)
                     trace_len=len(newTrace.data)
-                    if trace_len < 1:
-                        break
-                    #filter the new data and trim
-                    xin=self.customMetadata[newTrace.id]['filterState'];
-                    T=np.arange(0.0, trace_len)
-                    T *= dt
-                    tout, yout, xout =signal.lsim(self.filter, newTrace.data, T, X0=xin)
-                    newTrace.data = yout
-                    
-                    #Update the trace metadata
-                    self.customMetadata[trace.id]['MAX']=np.max(newTrace.data)
-                    self.customMetadata[trace.id]['MIN']=np.min(newTrace.data)
-                    self.customMetadata[trace.id]['MEAN']=np.mean(newTrace.data)                    
-                    self.customMetadata[newTrace.id]['filterState']=xout[-1]
-                    self.customMetadata[newTrace.id]['endtime']=newTrace.stats.endtime
-                    self.append(newTrace)
+                    if trace_len > 0:
+                        #filter the new data and trim
+                        xin=self.customMetadata[newTrace.id]['filterState'];
+                        T=np.arange(0.0, trace_len)
+                        T *= dt
+                        tout, yout, xout =signal.lsim(self.filter, newTrace.data, T, X0=xin)
+                        newTrace.data = yout
+
+                        #Update the trace metadata
+                        self.customMetadata[trace.id]['MAX']=np.max(newTrace.data)
+                        self.customMetadata[trace.id]['MIN']=np.min(newTrace.data)
+                        self.customMetadata[trace.id]['MEAN']=np.mean(newTrace.data)
+                        self.customMetadata[newTrace.id]['filterState']=xout[-1]
+                        self.customMetadata[newTrace.id]['endtime']=newTrace.stats.endtime
+                        self.append(newTrace)
                     
             else:#This trace is only present in the raw stream but has never been filtered
                 newTrace=trace.copy()


### PR DESCRIPTION
These are the changes we're running at LHO.

1. A dead thread leads to a thread restart rather than a restart of the whole script.
2. Handle a timeout exception in the run thread (probably not needed.)
3. Handle a case where a data fetch could be empty but was assumed to have data.